### PR TITLE
Imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,14 +6,14 @@ Date: 2015-06-12
 Author: Paulo I. Prado, Murilo Dantas Miranda and Andre Chalom
 Maintainer: Paulo I. Prado <prado@ib.usp.br>
 Depends:
+    stats,
     bbmle
 Imports:
+    MASS,
+    methods,
     graphics,
     grDevices,
-    stats,
-    methods,
     VGAM,
-    MASS,
     poilog,
     GUILDS
 Suggests:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,14 +6,15 @@ Date: 2015-06-12
 Author: Paulo I. Prado, Murilo Dantas Miranda and Andre Chalom
 Maintainer: Paulo I. Prado <prado@ib.usp.br>
 Depends:
-    stats,
-    bbmle,
-    poilog
+    bbmle
 Imports:
-    MASS,
-    methods,
     graphics,
+    grDevices,
+    stats,
+    methods,
     VGAM,
+    MASS,
+    poilog,
     GUILDS
 Suggests:
     vegan

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -34,5 +34,6 @@ importFrom("GUILDS", maxLikelihood.ESF)
 import(
     stats,
     methods,
+    MASS,
     bbmle,
     poilog)

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -24,14 +24,15 @@ exportMethods(plot, points, lines, octavpred, radpred, qqsad, qqrad)
 exportMethods(show, nobs, AIC, AICc)
 ## IMPORTS ##
 ## Import specific functions from other packages used by new methods
-importFrom("graphics", plot, points, lines)
+importFrom("graphics", plot, points, lines, abline, axis, hist, par)
+importFrom("grDevices", axisTicks, dev.interactive, devAskNewPage)
 #importFrom("bbmle", AICc)
 ## Import a single function from VGAM and GUILDS
 importFrom("VGAM",zeta)
 importFrom("GUILDS", maxLikelihood.ESF)
 ## Import all packages listed as Imports or Depends
 import(
+    stats,
     methods,
-    MASS,
     bbmle,
     poilog)


### PR DESCRIPTION
Fixing Imports for new r-devel version. 

Also, moved poilog to Imports as we don't need to make any function from poilog available to the end user.